### PR TITLE
Config for pip/pypi/package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+import pathlib
+from setuptools import setup
+
+# The directory containing this file
+HERE = pathlib.Path(__file__).parent
+
+# The text of the README file
+README = (HERE / "README.md").read_text()
+
+# This call to setup() does all the work
+setup(
+    name="pygame-text",
+    version="1.0.0",
+    description="Convenience functions for drawing using the pygame.font module.",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    url="https://github.com/cosmologicon/pygame-text",
+    author="cosmologicon",
+    author_email="cosmologicon@gmail.com",
+    license="CC0 1.0 Universal",
+    classifiers=[
+    ],
+    python_requires=">=2.7",
+    packages=["ptext"],
+    include_package_data=True,
+    install_requires=["pygame"],
+)


### PR DESCRIPTION
Here's the tutorial for putting things on pypi: https://packaging.python.org/tutorials/packaging-projects/

I'm not quite sure how to make setup.py work when there's just one file like `ptext.py`, so you'll probably need to change that or fiddle with it. I also arbitrarily chose the name pygame-text, but you'll need to register that on pypi before you can upload this. But once you do...

To package run:
`python setup.py sdist bdist_wheel`

To upload that package to pypi:
`twine upload --repository-url https://upload.pypi.org/legacy/ dist/1.0.0`